### PR TITLE
feat: add webp support according to docs 

### DIFF
--- a/lib/refinements.js
+++ b/lib/refinements.js
@@ -2,7 +2,7 @@ const t = require('tcomb')
 
 module.exports = {
   Absoluteurl: t.refinement(t.String, (u) => /^\/\/|:\/\//.test(u), 'Absolute url'),
-  Imagepath: t.refinement(t.String, (i) => /.(jpg|jpeg|gif|png|svg)$/.test(i), 'Image file'),
+  Imagepath: t.refinement(t.String, (i) => /.(jpg|jpeg|webp|gif|png|svg)$/.test(i), 'Image file'),
 
   /**
    * Ensures that value does not exceed specified length

--- a/tests/refinements.test.js
+++ b/tests/refinements.test.js
@@ -29,6 +29,7 @@ describe('Tcomb refinement', () => {
     it('should pass path with image file', () => {
       expect(r.Imagepath('file.jpg')).toMatchSnapshot()
       expect(r.Imagepath('file.jpeg')).toMatchSnapshot()
+      expect(r.Imagepath('file.webp')).toMatchSnapshot()
       expect(r.Imagepath('file.png')).toMatchSnapshot()
       expect(r.Imagepath('file.gif')).toMatchSnapshot()
       expect(r.Imagepath('file.svg')).toMatchSnapshot()


### PR DESCRIPTION
В документации Оффера (https://yandex.ru/support/merchants/ru/offers#picture) описано, что "Принимаются изображения в формате JPEG, PNG или WEBP."